### PR TITLE
Refactor index.py to pythonic / PEP8 style.

### DIFF
--- a/index.py
+++ b/index.py
@@ -1,59 +1,85 @@
-from bottle import *
-from process import sitemapProcess
-from generictemplate import buildgeneric
+# 3rd-party
+from bottle import error
+from bottle import get
+from bottle import redirect
+from bottle import request
+from bottle import route
+from bottle import run
+from bottle import static_file
+from bottle import view
 
-# setup static folder routes
-# javascript
+# Local
+from generictemplate import buildgeneric
+from process import sitemapProcess
+
+
 @get('/<filename:re:.*\.js>')
 def javascript(filename):
-	return static_file(filename, root='static/js')
-# stylesheets
+    """Static route for javascript."""
+    return static_file(filename, root='static/js')
+
+
 @get('/<filename:re:.*\.css>')
 def stylesheet(filename):
-	return static_file(filename, root='static/css')
-# images
+    """Static route for stylesheets."""
+    return static_file(filename, root='static/css')
+
+
 @get('/<filename:re:.*\.(jpg|png|gif|ico)>')
 def image(filename):
-	return static_file(filename, root='static/images')
-# fonts
+    """Static route for images."""
+    return static_file(filename, root='static/images')
+
+
 @get('/<filename:re:.*\.(eot|ttf|woff|svg)>')
 def font(filename):
-	return static_file(filename, root='static/fonts')
+    """Static route for fonts."""
+    return static_file(filename, root='static/fonts')
+
 
 @get('/<filename:re:.*\.zip>')
 def zip(filename):
-	return static_file(filename, root='static/themezips')
+    """Static route for zipped themes."""
+    return static_file(filename, root='static/themezips')
 
-# custom 404
+
 @error(404)
 @view('404')
 def error404(page_title='404 Error'):
-	return dict(page_title=page_title)
+    """Generate our custom 404 Error page."""
+    return dict(page_title=page_title)
 
-# index page call
+
 @route('/')
 @view('index')
 def index(page_title='Index'):
-	return dict(page_title=page_title)
+    """Generate the main index page."""
+    return dict(page_title=page_title)
 
-# process post from index
+
 @route('/process', method='post')
 @view('process')
 def process(page_title='Site Theme Info'):
-	sitemap = request.forms.get('sitemap')
-	themename = request.forms.get('themename')
-	nursery = request.forms.get('nursery')
-	siteinfo = sitemapProcess(sitemap,themename,nursery)
-	return dict(siteinfo=siteinfo,page_title=page_title)
+    """Process POSTed form for theme info."""
+    sitemap = request.forms.get('sitemap')
+    themename = request.forms.get('themename')
+    nursery = request.forms.get('nursery')
+    siteinfo = sitemapProcess(sitemap, themename, nursery)
+    return dict(siteinfo=siteinfo, page_title=page_title)
+
 
 @route('/process', method='get')
 def processget():
-	redirect('/')
+    """Redirect if request method is GET."""
+    redirect('/')
+
 
 @route('/generic')
 def generic():
-	buildgeneric()
-	redirect('/BuildTemplate.zip')
+    """Redirect to build template."""
+    buildgeneric()
+    redirect('/BuildTemplate.zip')
+
 
 # run host
 run(host='0.0.0.0', port=8080, debug=True)


### PR DESCRIPTION
Hi Richard,

Top tips for Python style: https://www.python.org/dev/peps/pep-0008/

_Basically the changes I've made in this patch are:_
- Explicit imports. One per line. Ordered by group (**future**, standard library, 3rd-party, local) and alphabetical within those.
- Two line-breaks between top level code items. (within funcs and classes it's one line :))
- Changed comments to docstrings so that Python can introspect itself... Python uses docstrings for documentation and these can be used programmatically.
- Normal spacing between elements e.g. (item1, item2) instead of (item1,item2)

_Stuff I haven't done:_
- Class names are CamelCase, constants are UPPERCASE, all else is lowercase.

Hope that's a useful starting point? :+1: 
